### PR TITLE
Fixed a bug in test/run.sh

### DIFF
--- a/tests/run.sh
+++ b/tests/run.sh
@@ -18,7 +18,7 @@ if   [ $D8PATH ]  && [ -x $D8PATH ]; then
 elif [ $JSCPATH ] && [ -x $JSCPATH ]; then
   RUNNER=$JSCPATH;
 elif [ $JPATH ]   && [ -x $JPATH ]; then
-  RUNNER='$JPATH -classpath ../util/js.jar org.mozilla.javascript.tools.shell.Main';
+  RUNNER="$JPATH -classpath ../util/js.jar org.mozilla.javascript.tools.shell.Main";
 else
   echo "FAILED: No JavaScript Runtime Found! Please install Java or the V8 Shell (d8) and add them to your \$PATH"
   exit 1;


### PR DESCRIPTION
Symptom of the bug

```
$ ./run.sh 
====================================================================
= Using runtime: $JPATH -classpath ../util/js.jar org.mozilla.javascript.tools.shell.Main
=-------------------------------------------------------------------
= Unit Tests
====================================================================

./run.sh: line 33: $JPATH: command not found

====================================================================
= Perf Tests
====================================================================

./run.sh: line 40: $JPATH: command not found
```
