### PR TITLE
Start the hashCode at 1 to work with invalid check like !!x.hashCode

### DIFF
--- a/src/c.js
+++ b/src/c.js
@@ -255,7 +255,7 @@ c.approx = function(a /*double*/, b /*double*/) {
   return (Math.abs(av - bv) < Math.abs(av) * epsilon);
 };
 
-var count = 0;
+var count = 1;
 c._inc = function() { return count++; };
 
 c.parseJSON = function(str) {


### PR DESCRIPTION
In HashTable.js the keyCode function is written as :

    var keyCode = function(key) {
      var kc = (!!key.hashCode) ? key.hashCode : key.toString();
      return kc;
    };

When the hashCode value is 0 then !!hashCode is false and the result of toString() is used.

On a Variable the toString is build using the current value, then when the internal value change it's keyCode value change. Trying to fetch a stored Variable after a change of value will then fail (For example when doing solver.suggestValue)