### PR TITLE
Add a correct check for number with default value

### DIFF
--- a/src/Expression.js
+++ b/src/Expression.js
@@ -10,13 +10,14 @@
 "use strict";
 
 c.Expression = c.inherit({
+
   initialize: function(clv /*c.AbstractVariable*/, value /*double*/, constant /*double*/) {
     if (c.GC) console.log("new c.Expression");
-    this.constant = (typeof constant == "number" && !isNaN(constant)) ? constant : 0;
+    this.constant = c.checkNumber(constant, 0);
     this.terms = new c.HashTable();
 
     if (clv instanceof c.AbstractVariable) {
-      this.setVariable(clv, typeof value == 'number' ? value : 1);
+      this.setVariable(clv, c.checkNumber(value, 1) );
     } else if (typeof clv == "number") {
       if (!isNaN(clv)) {
         this.constant = clv;
@@ -113,7 +114,7 @@ c.Expression = c.inherit({
       expr = new c.Expression(expr);
       if(c.trace) console.log("addExpression: Had to cast a var to an expression");
     }
-    n = n || 1;
+    n = c.checkNumber(n, 1);
     this.constant += (n * expr.constant);
     expr.terms.each(function(clv, coeff) {
       // console.log("clv:", clv, "coeff:", coeff, "subject:", subject);

--- a/src/c.js
+++ b/src/c.js
@@ -198,6 +198,10 @@ c.assert = function(f /*boolean*/, description /*String*/) {
   }
 };
 
+c.checkNumber = function(value, otherwise){
+  return (typeof value === "number" && !isNaN(value)) ? value : otherwise;
+};
+
 c.plus = function(e1, e2) {
   if (!(e1 instanceof c.Expression)) {
     e1 = new c.Expression(e1);


### PR DESCRIPTION
Otherwise on line 116 in Expression.js when n was 0 it was replaced by 1 and then : 

```
var solver = new c.SimplexSolver();
var x = new c.Variable({ name: "x" });
var y = new c.Variable({ name: "y" });
solver.addConstraint( new c.Equation(x, 12));
solver.addConstraint( new c.Equation(y, new c.Expression(x).times(0)) );
solver.resolve();
console.log(x.value + " - " + y.value);
```

Output :   

```
"12 - 12"
```
