### PR TITLE
Correction for the test to work when hashCode == 0

### DIFF
--- a/src/HashTable.js
+++ b/src/HashTable.js
@@ -34,7 +34,7 @@
 "use strict";
 
 var keyCode = function(key) {
-  var kc = (!!key.hashCode) ? key.hashCode : key.toString();
+  var kc = ("hashCode" in key) ? key.hashCode : key.toString();
   return kc;
 };
 


### PR DESCRIPTION
Better correction to #45.
The c._inc() function start at 0. the result of toString is then used instead of the hashCode but then :

On a Variable the toString is build using the current value, when the internal value change it's keyCode value change. Trying to fetch a stored Variable after a change of value will then fail (For example when doing solver.suggestValue)
