### PR TITLE
Strength toString using non-existent isRequired

### DIFF
--- a/src/Strength.js
+++ b/src/Strength.js
@@ -23,7 +23,7 @@ c.Strength = c.inherit({
   },
 
   toString: function() {
-    return this.name + (!this.isRequired ? (":" + this.symbolicWeight) : "");
+    return this.name + (!this.required ? (":" + this.symbolicWeight) : "");
   },
 });
 


### PR DESCRIPTION
Changed to use `required` getter instead as I think was intended. Minor, but helpful when comparing verbose logging for parity on a port.