### PR TITLE
Solver - insertErrorVar look up on incorrect value

### DIFF
--- a/src/SimplexSolver.js
+++ b/src/SimplexSolver.js
@@ -955,7 +955,7 @@ c.SimplexSolver = c.inherit({
 
   insertErrorVar: function(cn /*c.Constraint*/, aVar /*c.AbstractVariable*/) {
     c.trace && c.fnenterprint("insertErrorVar:" + cn + ", " + aVar);
-    var constraintSet = /* Set */this._errorVars.get(aVar);
+    var constraintSet = /* Set */this._errorVars.get(cn);
     if (!constraintSet) {
       constraintSet = new c.HashSet();
       this._errorVars.set(cn, constraintSet);


### PR DESCRIPTION
Ran into a type error here when porting, it is fetching from a Map of
Constraint:Set and instead was passing in an AbstractVariable. This
seems accidental - if you notice what would happen is every single time
a new set is created (because the result is never found), this also
probably makes garbage as a side effect.